### PR TITLE
Add $singular_name and $plural_name static variables for ShopFront

### DIFF
--- a/src/Model/ShopFrontSection.php
+++ b/src/Model/ShopFrontSection.php
@@ -30,6 +30,10 @@ class ShopFrontSection extends DataObject
         'Sort' => 'Int',
     ];
 
+    private static $singular_name = 'Shop Front Section';
+
+    private static $plural_name = 'Shop Front Sections';
+
     private static $has_one = [
         'ShopFront' => ShopFrontPage::class, // Parent relationship - indicates which shopfront page this section is on
         'ProductCategory' => ProductCategory::class,

--- a/src/Page/ShopFrontPage.php
+++ b/src/Page/ShopFrontPage.php
@@ -30,6 +30,10 @@ class ShopFrontPage extends Page
 
     private static $cascade_deletes = ['Sections'];
 
+    private static $singular_name = 'Shop Front Page';
+
+    private static $plural_name = 'Shop Front Pages';
+
     public function getCMSFields()
     {
         $fields = parent::getCMSFields();


### PR DESCRIPTION
$singular_name and $plural_name static variables are added in order to show pagetype name on the CMS.

Modified classes are:

- ShopFrontPage
- ShopFrontSection